### PR TITLE
Фул для ОСЩ

### DIFF
--- a/Resources/Prototypes/Totohka/blueshield.yml
+++ b/Resources/Prototypes/Totohka/blueshield.yml
@@ -21,13 +21,8 @@
   requireAdminNotify: true
   supervisors: job-supervisors-centcom
   canBeAntag: false
-  access:
-  - Command
-  - Security
-  - Maintenance
-  - Cryogenics
-  - External
-  - Brig
+  accessGroups:
+  - AllAccess
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
Так как люди постоянно играя на ОСЩ просят выдать себе фул, а на вики это у нас никак не ругается решил выдать ему полный доступ. :adv_cl: Фул для ОСЩ.
Теперь у офицера синего щита будет полный доступ.
