### PR TITLE
Удалены бригмедик и ОСЩ из "На определённых станциях"

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -122,6 +122,4 @@
   - Zookeeper
   - Psychologist
   - Pilot # Corvax-Pilot
-  - Brigmedic #Adventure
-  - Blueshield #Adventure
   primary: false


### PR DESCRIPTION
Из за этого багался цвет имени в чате + они есть на всех наших станциях что у нас в пуле так что смысла в этом не много.
