### PR TITLE
ПИИ как позитронный мозг в боргах.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -42,6 +42,7 @@
     wipeVerbPopup: pai-system-wiped-device
     stopSearchVerbText: pai-system-stop-searching-verb-text
     stopSearchVerbPopup: pai-system-stopped-searching
+  - type: BorgBrain
   - type: Examiner
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
@@ -93,6 +94,7 @@
     roleName: pai-system-role-name-syndicate
     roleDescription: pai-system-role-description-syndicate
     roleRules: ghost-role-information-familiar-rules
+  - type: BorgBrain
   - type: IntrinsicRadioTransmitter
     channels:
     - Syndicate
@@ -125,6 +127,7 @@
     roleName: pai-system-role-name-potato
     roleDescription: pai-system-role-description-potato
     roleRules: ghost-role-information-familiar-rules
+  - type: BorgBrain
   - type: Appearance
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
Теперь персональный искуственный интелект в любом его обличии можно запихнуть в борга как позитронный мозг. Вы можете сделать своего ПИИ более полезным! Теперь в нём будет гораздо больше смысла. Добавит интересный опыт отыгрыша РП, когда ПИИ синдиката засунут в обычного борга. Вообщем полезное обновление, как я считаю.

P.S. Заодно разобрался с гитхабом, ура.
